### PR TITLE
Fixes for 1.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -58,11 +58,7 @@ If you're interested in protecting other web applications with Duo's two-factor 
 == Changelog ==
 
 = 1.1 =
-* Encode text box attrs
-* Expire login form after 1 hour
-* wp_redirect -> wp_safe_redirect
-* Improved readme install guide
-* Removed old argument to duo_sign_request (fixes error seen by users)
+* Minor tweaks
 
 = 1.0 =
 * Initial release!


### PR DESCRIPTION
- duo login form expires in 1 hour
- escape text box values
- wp_safe_redirect
