### PR TITLE
Fix for multisite login

### DIFF
--- a/duo_wordpress.php
+++ b/duo_wordpress.php
@@ -88,7 +88,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
             <script>
             Duo.init({
                 'host': <?php echo "'" . $host . "'"; ?>,
-                'post_action': '<?php echo esc_url(network_site_url('wp-login.php', 'login_post')) ?>',
+                'post_action': '<?php echo esc_url(site_url('wp-login.php', 'login_post')) ?>',
                 'sig_request':<?php echo "'" . $request_sig . "'"; ?>
             });
             </script>


### PR DESCRIPTION
Changes the logic, to return the url of the current site that the user
is on an not the primary site on network. Fixes bug with multisite
login on sub domain configuration. This code has not been tested on sub directory configuration, however I believe the logic is sound. 

fix duosecurity/duo_wordpress#4
