### PR TITLE
Made github repo compatible with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+        "name"       : "duosecurity/duo_wordpress",
+        "description": "Duo WordPress",
+        "homepage"   : "https://github.com/duosecurity/duo_wordpress",
+        "type"       : "wordpress-plugin",
+        "license"    : "GPL-2.0+",
+        "authors"    : [
+                {
+                        "name"    : "Duo Security",
+                        "homepage": "http://www.duosecurity.com/"
+                }
+        ],
+        "require": {
+                "composer/installers": "~1.0"
+        }
+}


### PR DESCRIPTION
This addition is a simple json file, that adds composer support to this github repo. 

[Composer](https://getcomposer.org/) is a very popular dependency Manager for PHP. The composers is run and dependency are grabbed from version control and built into the package. This file allows me and others using composer, to build their sites directly from this repo. The file is innocuous and doesn't require updating. It also is not required on the WordPress svn so doesn't need to be copied over (it will be not hurt if it is on the svn repo).

I would be very grateful if you merged this change, as it would help us to use your product. 

Jonathan Harris - IPC Media 
