### PR TITLE
Hook to bypass JetPack Protect

### DIFF
--- a/duo_wordpress.php
+++ b/duo_wordpress.php
@@ -813,6 +813,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
         add_filter('plugin_action_links', 'duo_add_link', 10, 2 );
     }
 
+    function duo_bypass_jetpack_protect( $ip ) {
+        if ( duo_auth_enabled() ) {
+            return true;
+        }
+        return false;
+    }
+    add_filter( 'jpp_allow_login', 'duo_bypass_jetpack_protect', 10, 1 );
+
     add_action('init', 'duo_verify_auth', 10);
 
     add_action('clear_auth_cookie', 'duo_unset_cookie', 10);


### PR DESCRIPTION
Adds a function checking if Duo if active and binds it to the new hook that bypasses the JetPack Protect plugin module. This hook was added to JetPack in v4.4:
https://developer.jetpack.com/2016/11/21/new-hooks-jetpack-44/

This should perhaps be made a user-settable option?