### PR TITLE
Save empty list when we get no duo_roles parameter in the POST body

### DIFF
--- a/duo_wordpress.php
+++ b/duo_wordpress.php
@@ -462,6 +462,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
             $roles = $_POST['duo_roles'];
             $result = update_site_option('duo_roles', $roles);
         }
+        else {
+            $result = update_site_option('duo_roles', []);
+        }
 
         if(isset($_POST['duo_xmlrpc'])) {
             $xmlrpc = $_POST['duo_xmlrpc'];


### PR DESCRIPTION
Summary:
When the wordpress settings page for multisite admin is submitted, checkbox-based
parameters with all empty checkboxes do not appear in the POST body. This is correctly handled in
the case of `duo_xmlrpc` where a missing value defaults to 'on' (duo_wordpress.php:474) but was
unhandled in the case of `duo_roles` leading to the behavior that submitting no roles left the roles
value in the database unmodified rather than saving "no roles." This has been correct in this diff.

It would appear this "bug" has existed for quite some time as it still appeared in wordpress 4.3
and I suspect that the way checkboxes are submitted in POST requests it not something that wordpress
changes frequently.

Why would anyone want to submit blank roles?
Ironically this is actually part of our test plan. The reason is that users with "No role for this
site" (aka the role "None") will always get 2FA even with all roles unchecked. If an
administrator wanted 2FA only for users without a role then they would uncheck all boxes.