### PR TITLE
Ensure constants are global

### DIFF
--- a/duo_wordpress.php
+++ b/duo_wordpress.php
@@ -29,10 +29,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
     require_once('duo_web/duo_web.php');
-    $DuoAuthCookieName = 'duo_wordpress_auth_cookie';
-    $DuoSecAuthCookieName = 'duo_secure_wordpress_auth_cookie';
-    $DuoDebug = false;
-    $DuoPing = '/auth/v2/ping';
+    $GLOBALS['DuoAuthCookieName'] = 'duo_wordpress_auth_cookie';
+    $GLOBALS['DuoSecAuthCookieName'] = 'duo_secure_wordpress_auth_cookie';
+    $GLOBALS['DuoDebug'] = false;
+    $GLOBALS['DuoPing'] = '/auth/v2/ping';
 
     function parameterize($key, $value) {
         return sprintf('%s="%s"', $key, $value);


### PR DESCRIPTION
If this plugin is included with a non-global scope the implicit scoping of variables at the top of the file could cause problems for other parts of the plugin that requires these constants to be set. These changes ensure that we are writing to the global version of these variables which are referenced later on.