### PR TITLE
Add a filter to control MFA requirements per-user

### DIFF
--- a/duo_wordpress.php
+++ b/duo_wordpress.php
@@ -184,6 +184,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
         }
 
         /*
+         * Determine whether or not a particular user should be required
+         * to use multi-factor authentication.
+         *
+         * @param null|bool $required Whether or not to require MFA. Leave
+         *                            null to use normal check code path.
+         * @param WP_User   $user     The authenticating user.
+         */
+        $result = apply_filters('duo_require_mfa_for_user', null, $user);
+
+        if (!is_bool($result)) {
+            return $result;
+        }
+
+        /*
          * Mainly a workaround for multisite login:
          * if a user logs in to a site different from the one 
          * they are a member of, login will work however


### PR DESCRIPTION
We have a need to control dynamically whether or not a user is required to access a site via MFA, but don't want to tie it to roles.

This solution adds a filter which receives the WP_User object for advanced filtering. For example, allowing users with certain email addresses to bypass MFA:

```php
add_filter( 'duo_require_mfa_for_user', function ( ?bool $required, WP_User $user ) : ?bool {
    $segments = explode( '@', $user->email );

    $domain = end( $segments );

    return ( $domain === 'privileged-domain.com' ) ?: $required;
}, 10, 2 );
```

This should enable more complex integrations, for instance if you are integrating with multiple MFA providers or MFA and SSO simultaneously.