### PR TITLE
Add action hook on Duo screen to permit style tweaks

### DIFF
--- a/duo_wordpress.php
+++ b/duo_wordpress.php
@@ -116,6 +116,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
                     background: transparent;
                 }
             </style>
+            
+            <?php do_action( 'duo_login_head' ); ?>
         </head>
 
         <body class="login" >


### PR DESCRIPTION
Adds a `duo_login_head` hook which fires before the closing `</head>` tag on the Duo screen, so users can output custom styles or scripts.

We want to replace the WordPress logo with our own logo, and this will give us the means to do that without modifying core files.