### PR TITLE
Skip Duo when invoked from CLI

### DIFF
--- a/duo_wordpress.php
+++ b/duo_wordpress.php
@@ -158,6 +158,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
             return false; //allows the XML-RPC protocol for remote publishing
         }
 
+        if (defined('WP_CLI') && WP_CLI) { 
+            duo_debug_log('Found a WP-CLI request. Skipping second factor');
+            return false; //allows WP-CLI commands to be invoked with the `--user` flag
+        }
+
         if (duo_get_option('duo_ikey', '') == '' || duo_get_option('duo_skey', '') == '' ||
             duo_get_option('duo_host', '') == '') {
             return false;


### PR DESCRIPTION
When using WP-CLI with the `--user` flag to perform an action as a given user, Duo is invoked. It's not possible to set or read cookies from the CLI, so the Duo integration is not possible. This PR, therefore, bypasses Duo if the current request is in a CLI context.